### PR TITLE
JS task: Support style import

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-esbuild": "^4.10.1",
     "rollup-plugin-external-globals": "^0.6.1",
-    "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-inject-process-env": "^1.3.1",
     "rollup-plugin-polyfill-node": "^0.10.2",
     "rollup-plugin-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-esbuild": "^4.10.1",
     "rollup-plugin-external-globals": "^0.6.1",
+    "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-inject-process-env": "^1.3.1",
     "rollup-plugin-polyfill-node": "^0.10.2",
     "rollup-plugin-styles": "^4.0.0",

--- a/task/index.js
+++ b/task/index.js
@@ -64,7 +64,7 @@ function createTaskConfigs({ config, task }) {
     format: task.task === 'sass' ? 'es' : 'iife',
 
     // For styles plugin
-    assetFileNames: task.task === 'sass' ? '[name]' : '',
+    assetFileNames: task.task === 'sass' ? '[name]' : '[name].module[extname]',
 
     ...(task.output || {}),
   }

--- a/task/js.js
+++ b/task/js.js
@@ -3,6 +3,7 @@ const path = require('path')
 // Rollup plugins
 const alias = require('@rollup/plugin-alias')
 const commonjs = require('@rollup/plugin-commonjs')
+const css = require('rollup-plugin-import-css')
 const esbuild = require('rollup-plugin-esbuild').default
 const externalGlobals = require('rollup-plugin-external-globals')
 const image = require('@rollup/plugin-image')
@@ -165,6 +166,8 @@ function createOptionsForTaskType(config, task) {
         // Option to leave require() uncompiled for some modules
         ignore: [],
       }),
+
+      css(),
 
       json(),
 

--- a/task/js.js
+++ b/task/js.js
@@ -3,7 +3,6 @@ const path = require('path')
 // Rollup plugins
 const alias = require('@rollup/plugin-alias')
 const commonjs = require('@rollup/plugin-commonjs')
-const css = require('rollup-plugin-import-css')
 const esbuild = require('rollup-plugin-esbuild').default
 const externalGlobals = require('rollup-plugin-external-globals')
 const image = require('@rollup/plugin-image')
@@ -13,6 +12,7 @@ const polyfillNode = require('rollup-plugin-polyfill-node')
 const { nodeResolve } = require('@rollup/plugin-node-resolve')
 const replace = require('@rollup/plugin-replace')
 const injectProcessEnv = require('rollup-plugin-inject-process-env')
+const styles = require('rollup-plugin-styles')
 
 function createOptionsForTaskType(config, task) {
   const {
@@ -167,7 +167,20 @@ function createOptionsForTaskType(config, task) {
         ignore: [],
       }),
 
-      css(),
+      /**
+       * Support styles import from JS
+       * https://github.com/Anidetrix/rollup-plugin-styles
+       * https://anidetrix.github.io/rollup-plugin-styles/interfaces/types.Options.html
+       */
+       styles({
+        // Enable CSS modules for file extension .module.css
+        autoModules: true,
+        extensions: ['css', 'scss'],
+        mode: 'extract',
+        sourceMap: true,
+        minimize: true,
+        ...(task.styles || {}),
+      }),
 
       json(),
 


### PR DESCRIPTION
Hi,

I ran into an issue while trying to use dependencies that import CSS directly from a JavaScript file. It seems that we can use this plugin ([rollup-plugin-import-css](https://www.npmjs.com/package/rollup-plugin-import-css)) to add support for it