### PR TITLE
JS task: Compatibility between importToGlobal and raw

### DIFF
--- a/task/js.js
+++ b/task/js.js
@@ -298,6 +298,8 @@ function createOptionsForTaskType(config, task) {
         ...(task.esbuild || {}),
       }),
 
+      ...(task.raw ? [raw(task.raw)] : []),
+
       /**
        * Transform imports into global variables
        *
@@ -382,8 +384,6 @@ function createOptionsForTaskType(config, task) {
        * @see https://github.com/rollup/plugins/tree/master/packages/inject
        */
       inject(globalToImport),
-
-      ...(task.raw ? [raw(task.raw)] : []),
 
       // Custom Rollup plugins per task
       ...(task.rollupPlugins || []),

--- a/task/js.js
+++ b/task/js.js
@@ -298,6 +298,7 @@ function createOptionsForTaskType(config, task) {
         ...(task.esbuild || {}),
       }),
 
+      // Raw plugin must be before externalGlobals
       ...(task.raw ? [raw(task.raw)] : []),
 
       /**


### PR DESCRIPTION
Hi Eliot!

I ran into a small issue while trying to use both `importToGlobal` and `raw` for the same script, with a `tangible.config.js` file similar to this one:
```javascript
module.exports = {
  build: [
    {
      src: './index.js',
      dest: './build.js',
      importToGlobal: {
        'dummy': 'window.dummyGlobal'
      },
      raw: {
        include : '*.txt',
      }
    }
  ]
}
```

When trying to run `roll dev` or `roll build` it returns the following error:
```
[rollup-plugin-external-globals] Unexpected token (2:8)
```

The issue seems to be that `externalGlobals()` is being applied on raw files

Changing the order so that `raw()` is called before `externalGlobals()` seems to fix the issue

Here is a little .zip with a minimal configuration to reproduce the issue:
[example.zip](https://github.com/TangibleInc/tangible-roller/files/14896595/example.zip)