### PR TITLE
Generate source maps during development only and remove from production release

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -3,6 +3,7 @@
  */
 
 const path = require('path')
+const fs = require('fs/promises')
 const rollup = require('rollup')
 const getFileSize = require('../utils/getFileSize')
 const displayError = require('../utils/displayError')
@@ -15,7 +16,7 @@ async function build(props) {
     return await inputOptions.build(props)
   }
 
-  const { cwd, rootDir } = config
+  const { cwd, rootDir, isDev } = config
 
   console.log('..Building from', path.relative(cwd, inputOptions.input))
 
@@ -41,6 +42,13 @@ async function build(props) {
     // , 'in', (duration / 1000).toFixed(2)+'s'
     `(${fileSize})`
   )
+
+  if (task.map === 'dev') {
+    // Remove source maps for production
+    await fs.rm(`${builtFile}.map`, {
+      force: true, // exceptions will be ignored if path does not exist
+    })
+  }
 }
 
 module.exports = build

--- a/config/index.js
+++ b/config/index.js
@@ -115,7 +115,14 @@ async function createConfig({ commandName, subproject }) {
     lint,
     serve,
     archive,
+    map = true // or 'dev'
   } = configJson instanceof Function ? await configJson() : configJson
+
+  for (const task of tasks) {
+    if (typeof task.map==='undefined') {
+      task.map = map
+    }
+  }
 
   // Ensure project dependencies are installed
   if (

--- a/config/index.js
+++ b/config/index.js
@@ -115,7 +115,7 @@ async function createConfig({ commandName, subproject }) {
     lint,
     serve,
     archive,
-    map = true // or 'dev'
+    map = 'dev' // Global default, can override per task
   } = configJson instanceof Function ? await configJson() : configJson
 
   for (const task of tasks) {

--- a/task/index.js
+++ b/task/index.js
@@ -59,9 +59,9 @@ function createTaskConfigs({ config, task }) {
         : task.dest,
     sourcemap: task.task === 'sass'
       ? false
-      : task.map === 'dev'
+      : task.map === 'dev' // See ../config for global default
         ? isDev // Only during development
-        : task.map !== false // true by default
+        : task.map !== false
     ,
 
     // Use default source map name to support dynamic exports and code splitting

--- a/task/index.js
+++ b/task/index.js
@@ -57,7 +57,12 @@ function createTaskConfigs({ config, task }) {
       task.task === 'sass'
         ? task.dest + '.tmp' // PostCSS emits its own file
         : task.dest,
-    sourcemap: task.task === 'sass' ? false : task.map !== false, // true by default
+    sourcemap: task.task === 'sass'
+      ? false
+      : task.map === 'dev'
+        ? isDev // Only during development
+        : task.map !== false // true by default
+    ,
 
     // Use default source map name to support dynamic exports and code splitting
     // sourcemapFile: task.dest + '.map',

--- a/test/tangible.config.js
+++ b/test/tangible.config.js
@@ -1,9 +1,10 @@
 module.exports = {
+  map: 'dev', // Source map during development only - Remove for production
   build: [
     {
       src: 'src/index.jsx',
       dest: 'build/test.min.js',
-      react: 'react'
+      react: 'react',
     },
     {
       src: 'src/index.jsx',
@@ -40,7 +41,6 @@ module.exports = {
     async function({ config, task = {} }) {
       console.log('Custom build function')
     }
-
   ],
   format: 'src',
   serve: {

--- a/test/tangible.config.js
+++ b/test/tangible.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-  map: 'dev', // Source map during development only - Remove for production
   build: [
     {
       src: 'src/index.jsx',
       dest: 'build/test.min.js',
       react: 'react',
+      map: true, // Test override global default (source map during development only, remove for production)
     },
     {
       src: 'src/index.jsx',


### PR DESCRIPTION
@nicolas-jaussaud I wanted to ask your opinion on this new feature.

I added a global config option (and per-task option) to generate source maps during development only (`roll dev`) and remove them for production (`roll build`).

```js
export default {
  map: 'dev',
  build: [ ... ]
}
```

My motivation was to **reduce the size of the plugin** for L&L. I found that WordPress and Gutenberg projects are also not publishing their source maps. But ACF does.

There are arguments in support of including source maps in production release, as can be seen in this discussion:

- WordPress/gutenberg#45251

The main advantage is that it improves debugging any JS issues that occur in production, so users can include a more helpful stack trace in the issue description. That's a pretty compelling reason, it's valuable and maybe worth a few extra megabytes.

In this case, a majority of devs preferred to not change the current default (no sourcemaps for prod), and instead added an option to enable it specifically.

- WordPress/gutenberg#46812

From this, I was considering making it the default for Tangible Roller also.

Would you be OK with that, or would you prefer to publish source maps by default? In the latter case, I can make it opt-in and keep the current behavior.