### PR TITLE
JS task: Improve support for commonjs-module and jsx transform

### DIFF
--- a/task/js.js
+++ b/task/js.js
@@ -362,7 +362,12 @@ function createOptionsForTaskType(config, task) {
                   continue
 
                 // Provide missing property "default"
-                const fn = `function() { if (${varName} && !${varName}.default) ${varName}.default = ${varName}; return ${varName} }`
+                const fn = `function() {
+                  if (${varName} && !${varName}.default) ${varName}.default = ${varName};
+                  if (${varName} && !${varName}.__module) ${varName}.__module = { exports: ${varName}, default: ${varName} };
+                  if (${varName} && '${varName}' === 'wp.element' && !${varName}.jsx) ${varName}.jsx = ${varName}.createElement;
+                  return ${varName};
+                }`
 
                 const type = id.split('?')[1]
 
@@ -370,6 +375,9 @@ function createOptionsForTaskType(config, task) {
                   return `{ __require: ${fn} }`
                 }
                 if (type === 'commonjs-external' || type === 'commonjs-proxy') {
+                  return `(${fn})()`
+                }
+                if(type === 'commonjs-module') {
                   return `(${fn})()`
                 }
 

--- a/task/js.js
+++ b/task/js.js
@@ -374,10 +374,11 @@ function createOptionsForTaskType(config, task) {
                 if (type === 'commonjs-wrapped') {
                   return `{ __require: ${fn} }`
                 }
-                if (type === 'commonjs-external' || type === 'commonjs-proxy') {
-                  return `(${fn})()`
-                }
-                if(type === 'commonjs-module') {
+                if (
+                  type === 'commonjs-external' ||
+                  type === 'commonjs-proxy' ||
+                  type === 'commonjs-module'
+                ) {
                   return `(${fn})()`
                 }
 


### PR DESCRIPTION
Hi @eliot-akira!

This is probably more an issue than a pull request, but as we found a workaround to fix it I thought it will be easier to visualize it even if it's not changes we will merge in the end

@lloyd-teamtangible and I recently noticed an issue with the build process when [@tanstack/react-query](https://www.npmjs.com/package/@tanstack/react-query) is used as a dependency and react mode is set to wp

Here is a .zip with a minimal setup to reproduce/see the issue: [tangible-roller.zip](https://github.com/user-attachments/files/16413902/tangible-roller.zip)

It seems that there are two issues in the build file, in this part (line to 2840 to 2874 in the .zip example):
```javascript
wp.element.__module.exports;

if (browser$1.env.NODE_ENV === 'production') {
  wp.element.__module.exports = { __require: function() { if (wp.element && !wp.element.default) wp.element.default = wp.element; return wp.element } }.__require();
} else {
  wp.element.__module.exports = { __require: function() { if (wp.element && !wp.element.default) wp.element.default = wp.element; return wp.element } }.__require();
}

var jsxRuntimeExports = wp.element.__module.exports;

// ...

var QueryClientProvider = ({
  client,
  children
}) => {

  // ...

  return /* @__PURE__ */ jsxRuntimeExports.jsx(QueryClientContext.Provider, { value: client, children });
};
```

The first issue is on the first line of the snippet, as `wp.element.__module` is not defined, so we added [this change](https://github.com/TangibleInc/tangible-roller/blob/e553e8e605aac65c0a4eebccb730eeb18d0dc0b3/task/js.js#L367) and [this change](https://github.com/TangibleInc/tangible-roller/blob/e553e8e605aac65c0a4eebccb730eeb18d0dc0b3/task/js.js#L380-L382) which seems to fix the issue as it will now be defined

The next second issue (which might not be linked to the first one at all) seems to be related to [JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) (which I'm not familiar with)

My understanding is that, when using JSX transform, the `jsx()` function is going to be used instead of `createElement()` 

As in the build file we have this:
```javascript
var jsxRuntimeExports = wp.element.__module.exports;

// ...

return /* @__PURE__ */ jsxRuntimeExports.jsx(QueryClientContext.Provider, { value: client, children });
```

`wp.element.jsx()`  is going to be used but won't be defined. To prevent that, we made a change to use `wp.element.jsx()` as an alias of `wp.element.createElement()`(in [this line](https://github.com/TangibleInc/tangible-roller/blob/e553e8e605aac65c0a4eebccb730eeb18d0dc0b3/task/js.js#L368)), and it seems to fix the issue

However, I'm not sure it's the right way to deal with the issue

If I understood correctly, with the configuration we have [here](https://github.com/TangibleInc/tangible-roller/blob/e553e8e605aac65c0a4eebccb730eeb18d0dc0b3/task/js.js#L278-L280) inside the esbuild plugin, we already shouldn't have `wp.element.jsx()` instead of `wp.element.createElement()` so I'm not sure what the issue is